### PR TITLE
Improve agent context with policy info

### DIFF
--- a/sinistros-ia-sistema-main/COMO_USAR.md
+++ b/sinistros-ia-sistema-main/COMO_USAR.md
@@ -135,6 +135,14 @@ R: A API funcionará, mas a análise dos agentes retornará erro.
 **P: Os agentes aprendem com o tempo?**
 R: Cada análise é independente, mas você pode ajustar as instruções dos agentes.
 
+## 🔧 Personalizando o Contexto Inicial
+
+A função `coletar_contexto_apolice_e_historico` (em `src/agents/context_helper.py`)
+monta um texto com detalhes da apólice e histórico do segurado que é enviado aos
+agentes. Edite essa função para consultar seus bancos ou APIs internas e incluir
+informações relevantes para o seu negócio. Basta retornar uma string com o
+conteúdo desejado.
+
 ## 🎯 Teste Agora!
 
 1. Execute: `python exemplo_uso_completo.py`

--- a/sinistros-ia-sistema-main/src/agents/context_helper.py
+++ b/sinistros-ia-sistema-main/src/agents/context_helper.py
@@ -1,0 +1,34 @@
+"""Utilities to build extra context for the claim agents."""
+from typing import Dict, Any
+
+from .claims_agent_system import consultar_apolice, consultar_historico_segurado
+
+
+def coletar_contexto_apolice_e_historico(sinistro: Dict[str, Any]) -> str:
+    """Return a text chunk with policy details and prior claim history."""
+    numero_apolice = sinistro.get("apolice", {}).get("numero")
+    documento = sinistro.get("segurado", {}).get("documento")
+
+    apolice = consultar_apolice(numero_apolice) if numero_apolice else {}
+    historico = consultar_historico_segurado(documento) if documento else {}
+
+    partes = []
+
+    if apolice:
+        partes.append("Detalhes da Apólice:")
+        partes.append(f"  - Número: {apolice.get('numero')}")
+        partes.append(f"  - Vigente: {'Sim' if apolice.get('vigente') else 'Não'}")
+        if apolice.get("coberturas"):
+            partes.append("  - Coberturas: " + ", ".join(apolice["coberturas"]))
+        if apolice.get("franquia") is not None:
+            partes.append(f"  - Franquia: {apolice['franquia']}")
+        if apolice.get("limite_indenizacao") is not None:
+            partes.append(f"  - Limite de Indenização: {apolice['limite_indenizacao']}")
+
+    if historico:
+        partes.append("\nHistórico do Segurado:")
+        partes.append(f"  - Sinistros Anteriores: {historico.get('sinistros_anteriores')}")
+        partes.append(f"  - Score de Risco: {historico.get('score_risco')}")
+        partes.append(f"  - Alertas de Fraude: {'Sim' if historico.get('alertas_fraude') else 'Não'}")
+
+    return "\n".join(partes)


### PR DESCRIPTION
## Summary
- add helper to build enriched context with policy and claim history
- update processar_sinistro to prepend the context
- refer to the context in agent instructions
- document how to customize the context provider

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6867294bfe3883259c8309c7c2607f7a