### PR TITLE
Add sinistro processing tests

### DIFF
--- a/sinistros-ia-sistema-main/tests/conftest.py
+++ b/sinistros-ia-sistema-main/tests/conftest.py
@@ -1,0 +1,67 @@
+import sys
+import types
+
+# Stub 'swarm' if missing
+if 'swarm' not in sys.modules:
+    swarm_stub = types.ModuleType('swarm')
+    class DummyAgent:
+        def __init__(self, name=None, model=None, instructions=None, tools=None, functions=None):
+            self.name = name
+    class DummySwarm:
+        def __init__(self, *args, **kwargs):
+            pass
+        def run(self, agent=None, messages=None):
+            return types.SimpleNamespace(
+                messages=[{"content": "Stub response"}],
+                agent=types.SimpleNamespace(name=getattr(agent, 'name', 'stub'))
+            )
+    swarm_stub.Agent = DummyAgent
+    def Swarm(*args, **kwargs):
+        return DummySwarm()
+    swarm_stub.Swarm = Swarm
+    sys.modules['swarm'] = swarm_stub
+
+# Stub 'fastapi' and key submodules if missing
+if 'fastapi' not in sys.modules:
+    fastapi_stub = types.ModuleType('fastapi')
+    class FastAPI:
+        def __init__(self, *args, **kwargs):
+            self.routes = []
+        def add_api_route(self, path, endpoint, methods=None, **kwargs):
+            self.routes.append((path, methods))
+        # decorators
+        def get(self, path, **kwargs):
+            def decorator(func):
+                self.add_api_route(path, func, methods=["GET"])
+                return func
+            return decorator
+        def post(self, path, **kwargs):
+            def decorator(func):
+                self.add_api_route(path, func, methods=["POST"])
+                return func
+            return decorator
+        def add_middleware(self, middleware_class, **kwargs):
+            pass
+    class HTTPException(Exception):
+        pass
+    class BackgroundTasks:
+        pass
+    def Depends(x=None):
+        pass
+    fastapi_stub.FastAPI = FastAPI
+    fastapi_stub.HTTPException = HTTPException
+    fastapi_stub.BackgroundTasks = BackgroundTasks
+    fastapi_stub.Depends = Depends
+    # Prepare submodules
+    responses = types.ModuleType('fastapi.responses')
+    responses.JSONResponse = lambda *a, **k: None
+    middleware = types.ModuleType('fastapi.middleware')
+    cors = types.ModuleType('fastapi.middleware.cors')
+    cors.CORSMiddleware = lambda *a, **k: None
+    middleware.cors = cors
+    fastapi_stub.responses = responses
+    fastapi_stub.middleware = middleware
+    sys.modules['fastapi'] = fastapi_stub
+    sys.modules['fastapi.responses'] = responses
+    sys.modules['fastapi.middleware'] = middleware
+    sys.modules['fastapi.middleware.cors'] = cors

--- a/sinistros-ia-sistema-main/tests/test_processar_sinistro.py
+++ b/sinistros-ia-sistema-main/tests/test_processar_sinistro.py
@@ -1,0 +1,38 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.agents.claims_agent_system import processar_sinistro
+
+
+SAMPLE_SINISTRO = {
+    "numero_sinistro": "SIN-001",
+    "data_ocorrencia": "2024-01-01",
+    "data_aviso": "2024-01-02",
+    "segurado": {"nome": "Joao", "documento": "00000000000"},
+    "apolice": {"numero": "AP-1", "produto": "Auto"},
+    "descricao": "Teste de sinistro",
+    "documentos": ["doc1.pdf"],
+    "valor_estimado": 1000.0,
+}
+
+
+def test_processar_sinistro(monkeypatch):
+    """Verifica retorno básico de processar_sinistro."""
+    if not os.getenv("OPENAI_API_KEY"):
+        class DummySwarm:
+            def run(self, agent=None, messages=None):
+                return SimpleNamespace(
+                    messages=[{"content": "Stub"}],
+                    agent=SimpleNamespace(name="dummy")
+                )
+        monkeypatch.setattr(
+            "src.agents.claims_agent_system.get_swarm_client",
+            lambda: DummySwarm()
+        )
+
+    resultado = processar_sinistro(SAMPLE_SINISTRO)
+
+    assert isinstance(resultado, dict)
+    for chave in ("mensagem", "agent_usado", "sinistro_numero"):
+        assert chave in resultado


### PR DESCRIPTION
## Summary
- add pytest fixtures to stub required libs
- add new tests for `processar_sinistro`

## Testing
- `pytest -q sinistros-ia-sistema-main/tests`

------
https://chatgpt.com/codex/tasks/task_e_686729468ec88325ba773f80592b20b7