### PR TITLE
Allow vision-agent-recreation frontend

### DIFF
--- a/sinistros-ia-sistema-main/.env.production
+++ b/sinistros-ia-sistema-main/.env.production
@@ -67,4 +67,4 @@ MAX_CONCURRENT_ANALYSES=10
 # ===== API =====
 API_V1_PREFIX=/api/v1
 API_RATE_LIMIT=100/minute
-API_CORS_ORIGINS=["https://app.empresa.com","https://dashboard.empresa.com"]
+API_CORS_ORIGINS=["https://app.empresa.com","https://dashboard.empresa.com","https://vision-agent-recreation.lovable.app"]


### PR DESCRIPTION
## Summary
- add `https://vision-agent-recreation.lovable.app` to `API_CORS_ORIGINS` in `.env.production`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bdaff85e0832584d03e00bfd7c90f