### PR TITLE
Update API_CORS_ORIGINS

### DIFF
--- a/.env
+++ b/.env
@@ -67,4 +67,4 @@ MAX_CONCURRENT_ANALYSES=10
 # ===== API =====
 API_V1_PREFIX=/api/v1
 API_RATE_LIMIT=100/minute
-API_CORS_ORIGINS=["https://app.empresa.com","https://dashboard.empresa.com"]
+API_CORS_ORIGINS=["https://app.empresa.com","https://dashboard.empresa.com","https://968b7b89-2c7e-4c58-a71d-c69f5a07e13c.lovableproject.com"]

--- a/sinistros-ia-sistema-main/.env.production
+++ b/sinistros-ia-sistema-main/.env.production
@@ -67,4 +67,4 @@ MAX_CONCURRENT_ANALYSES=10
 # ===== API =====
 API_V1_PREFIX=/api/v1
 API_RATE_LIMIT=100/minute
-API_CORS_ORIGINS=["https://app.empresa.com","https://dashboard.empresa.com"]
+API_CORS_ORIGINS=["https://app.empresa.com","https://dashboard.empresa.com","https://968b7b89-2c7e-4c58-a71d-c69f5a07e13c.lovableproject.com"]


### PR DESCRIPTION
## Summary
- allow requests from `https://968b7b89-2c7e-4c58-a71d-c69f5a07e13c.lovableproject.com`
- same update in production env file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `sudo systemctl restart sinistros.service` *(fails: systemd not running)*

------
https://chatgpt.com/codex/tasks/task_e_686fa8b4732c8325b40bc5f3efbd82a1